### PR TITLE
Simplify macOS linking by using clang as linker driver

### DIFF
--- a/configure
+++ b/configure
@@ -213,7 +213,10 @@ else
         echo "  2. Set LLVM_SYS_XXX_PREFIX environment variable"
         echo ""
         echo "Installation examples:"
-        echo "  macOS:  brew install llvm"
+        echo "  macOS (Homebrew): brew install llvm"
+        echo "  macOS (MacPorts): sudo port install llvm-21 clang-21"
+        echo "                    sudo port select --set llvm mp-llvm-21"
+        echo "                    sudo port select --set clang mp-clang-21"
         echo "  Ubuntu: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 21"
         echo "  Manual: export LLVM_SYS_211_PREFIX=/path/to/llvm"
         exit 1

--- a/openvaf/linker/src/lib.rs
+++ b/openvaf/linker/src/lib.rs
@@ -97,21 +97,6 @@ fn linker_with_args<'a>(
     // this environment variable too in recent versions.
     cmd.cmd().env("ZERO_AR_DATE", "1");
 
-    // On macOS, we always need to add the SDK sysroot for linking against system libraries
-    if flavor == LinkerFlavor::Ld64 && target.options.is_like_osx {
-        // Detect SDK path using xcrun
-        if let Ok(output) = std::process::Command::new("xcrun").args(["--show-sdk-path"]).output() {
-            if output.status.success() {
-                if let Ok(sdk_path) = String::from_utf8(output.stdout) {
-                    let sdk_path = sdk_path.trim();
-                    if !sdk_path.is_empty() {
-                        cmd.args(["-syslibroot", sdk_path]);
-                    }
-                }
-            }
-        }
-    }
-
     cmd.add_pre_link_args(target, flavor);
 
     add_objects(&mut *cmd);
@@ -170,17 +155,9 @@ fn get_linker<'a>(
             let path = path.unwrap_or_else(|| {
                 if is_msys2_environment() {
                     "gcc".into()
-                } else if flavor == LinkerFlavor::Ld64 {
-                    // For macOS, prefer LLVM's ld64.lld if available
-                    if let Some(llvm_prefix) = get_llvm_prefix() {
-                        let llvm_lld = PathBuf::from(llvm_prefix).join("bin/ld64.lld");
-                        if llvm_lld.exists() {
-                            return llvm_lld;
-                        }
-                    }
-                    "ld".into()
+                } else if cfg!(target_os = "macos") {
+                    "clang".into()
                 } else {
-                    // On macOS and Linux, use system ld
                     "ld".into()
                 }
             });
@@ -286,7 +263,8 @@ impl<'a> LdLinker<'a> {
     fn build_dylib(&mut self) {
         // On mac we need to tell the linker to let this library be rpathed
         if self.target.options.is_like_osx {
-            self.linker_arg("-dylib");
+            self.linker_arg("-dynamiclib");
+            // clang automatically handles -lSystem
         } else {
             self.linker_arg("-shared");
         }

--- a/openvaf/openvaf-driver/build.rs
+++ b/openvaf/openvaf-driver/build.rs
@@ -1,0 +1,17 @@
+// build.rs for openvaf-driver
+
+fn main() {
+    // Add rpath for LLVM on macOS
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(output) = std::process::Command::new("llvm-config")
+            .arg("--libdir")
+            .output()
+        {
+            if output.status.success() {
+                let libdir = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                println!("cargo:rustc-link-arg=-Wl,-rpath,{}", libdir);
+            }
+        }
+    }
+}

--- a/openvaf/target/src/spec/aarch64_apple_darwin.rs
+++ b/openvaf/target/src/spec/aarch64_apple_darwin.rs
@@ -7,21 +7,8 @@ pub fn target() -> Target {
     base.pre_link_args.insert(
         LinkerFlavor::Ld64,
         vec![
-            "-arch".to_string(),
-            "arm64".to_string(),
-            "-platform_version".to_string(),
-            "macos".to_string(),
-            "11.0".to_string(),
-            "11.0".to_string(),
-            "-undefined".to_string(),
-            "dynamic_lookup".to_string(),
+            "-Wl,-undefined,dynamic_lookup".to_string(),
         ],
-    );
-
-    // Link against libSystem which provides dyld_stub_binder
-    base.post_link_args.insert(
-        LinkerFlavor::Ld64,
-        vec!["-lSystem".to_string()],
     );
 
     Target {

--- a/openvaf/target/src/spec/x86_64_apple_darwin.rs
+++ b/openvaf/target/src/spec/x86_64_apple_darwin.rs
@@ -8,14 +8,7 @@ pub fn target() -> Target {
     base.pre_link_args.insert(
         LinkerFlavor::Ld64,
         vec![
-            "-arch".to_string(),
-            "x86_64".to_string(),
-            "-platform_version".to_string(),
-            "macos".to_string(),
-            "10.15".to_string(),
-            "10.15".to_string(),
-            "-undefined".to_string(),
-            "dynamic_lookup".to_string(),
+            "-Wl,-undefined,dynamic_lookup".to_string(),
         ],
     );
 


### PR DESCRIPTION
I ran into linking issues building OpenVAF on macOS (Apple Silicon, MacPorts LLVM 18). The current approach passes raw ld64 flags like `-syslibroot`, `-platform_version`, and `-arch` directly, which breaks in some configurations.

This PR uses `clang` as the linker driver on macOS instead. Clang already handles SDK detection, system library linking, and architecture selection, so the manual flag handling becomes unnecessary.

### Changes

**Linker selection** (`linker/src/lib.rs`):
- Use `clang` on macOS instead of `ld64.lld` / `ld`
- Use `-dynamiclib` instead of `-dylib` (clang syntax)
- Remove manual SDK sysroot detection (clang handles this)

**Target specs** (`target/src/spec/*_apple_darwin.rs`):
- Remove `-arch`, `-platform_version`, and `-lSystem` flags
- Keep only `-Wl,-undefined,dynamic_lookup`
- Clang infers the rest from the target triple

**Runtime linking** (`openvaf-driver/build.rs`):
- Query `llvm-config --libdir` at build time and embed the result as an rpath
- Eliminates the need to set `DYLD_LIBRARY_PATH` at runtime

**Documentation** (`configure`):
- Added MacPorts installation instructions alongside Homebrew

### Testing

- macOS, Apple Silicon (M2), MacPorts LLVM 18 and LLVM 21
- Built `openvaf`, compiled Verilog-A models to `.osdi`, loaded them in ngspice