### PR TITLE
feat: LLVM 22.1 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "llvm-sys"
+version = "221.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2abcc34a3b190f03c2a61b555f218f529589ff13657bdd2ff8ac3e85f2abe6bb"
+dependencies = [
+ "anyhow",
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex-lite",
+ "semver",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +946,7 @@ dependencies = [
  "llvm-sys 191.1.0",
  "llvm-sys 201.0.1",
  "llvm-sys 211.0.0",
+ "llvm-sys 221.0.1",
  "log",
  "mir",
  "target",
@@ -1032,6 +1047,7 @@ dependencies = [
  "llvm-sys 191.1.0",
  "llvm-sys 201.0.1",
  "llvm-sys 211.0.0",
+ "llvm-sys 221.0.1",
  "md5",
  "mini_harness",
  "mir_llvm",
@@ -1091,6 +1107,7 @@ dependencies = [
  "llvm-sys 191.1.0",
  "llvm-sys 201.0.1",
  "llvm-sys 211.0.0",
+ "llvm-sys 221.0.1",
  "log",
  "mini_harness",
  "mir",
@@ -1613,6 +1630,7 @@ dependencies = [
  "llvm-sys 191.1.0",
  "llvm-sys 201.0.1",
  "llvm-sys 211.0.0",
+ "llvm-sys 221.0.1",
  "md5",
  "mir",
  "mir_autodiff",

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If the binary is named `openvaf` it comes from the `branches/osdi_0.3` branch an
 
 ## LLVM Version Support
 
-OpenVAF-reloaded supports multiple LLVM versions from 18 to 21. You can choose which version to use at build time via Cargo features:
+OpenVAF-reloaded supports multiple LLVM versions from 18 to 22. You can choose which version to use at build time via Cargo features:
 
 | Feature | LLVM Version | Environment Variable | llvm-sys crate |
 |---------|--------------|----------------------|----------------|
@@ -81,6 +81,7 @@ OpenVAF-reloaded supports multiple LLVM versions from 18 to 21. You can choose w
 | `llvm19` | LLVM 19.1.x | `LLVM_SYS_191_PREFIX` | 191.0.0 |
 | `llvm20` | LLVM 20.1.x | `LLVM_SYS_201_PREFIX` | 201.0.1 |
 | `llvm21` | LLVM 21.1.x | `LLVM_SYS_211_PREFIX` | 211.0.0 |
+| `llvm22` | LLVM 22.1.x | `LLVM_SYS_221_PREFIX` | 221.0.1 |
 
 **Note:** There is no default LLVM version. You must specify the version explicitly using `--features llvmXX` or use the `./configure` script for auto-detection (see Building section).
 
@@ -174,10 +175,10 @@ export LLVM_SYS_181_PREFIX=$(brew --prefix llvm@18)
 export PATH="$(brew --prefix llvm@18)/bin:$PATH"
 ```
 
-### Using LLVM 21 (latest)
+### Using LLVM 22 (latest)
 ```bash
 brew install llvm
-export LLVM_SYS_211_PREFIX=$(brew --prefix llvm)
+export LLVM_SYS_221_PREFIX=$(brew --prefix llvm)
 export PATH="$(brew --prefix llvm)/bin:$PATH"
 ```
 
@@ -206,7 +207,7 @@ The easiest way to build is using the configure script which auto-detects your L
 
 The configure script will:
 1. Search for LLVM installations (via environment variables, PATH, or Homebrew on macOS)
-2. Select the newest available version (21 > 20 > 19 > 18)
+2. Select the newest available version (22 > 21 > 20 > 19 > 18)
 3. Save the configuration to `.llvm-version`
 
 You can also force a specific version:

--- a/build.sh
+++ b/build.sh
@@ -66,6 +66,7 @@ case "$LLVM_VERSION" in
     19) export LLVM_SYS_191_PREFIX="$LLVM_PREFIX" ;;
     20) export LLVM_SYS_201_PREFIX="$LLVM_PREFIX" ;;
     21) export LLVM_SYS_211_PREFIX="$LLVM_PREFIX" ;;
+    22) export LLVM_SYS_221_PREFIX="$LLVM_PREFIX" ;;
 esac
 
 # Add LLVM to PATH if needed

--- a/configure
+++ b/configure
@@ -21,7 +21,7 @@ Usage: $0 [OPTIONS]
 Auto-detect LLVM version and configure the build.
 
 Options:
-  --llvm=VERSION    Force specific LLVM version (18, 19, 20, or 21)
+  --llvm=VERSION    Force specific LLVM version (18, 19, 20, 21, or 22)
   --help            Show this help message
 
 After running configure, use ./build.sh to build with auto-detected settings,
@@ -32,6 +32,7 @@ Environment variables:
   LLVM_SYS_191_PREFIX   Path to LLVM 19 installation
   LLVM_SYS_201_PREFIX   Path to LLVM 20 installation
   LLVM_SYS_211_PREFIX   Path to LLVM 21 installation
+  LLVM_SYS_221_PREFIX   Path to LLVM 22 installation
 
 Examples:
   ./configure                           # Auto-detect
@@ -67,6 +68,7 @@ check_llvm_version() {
         19) env_var="LLVM_SYS_191_PREFIX" ;;
         20) env_var="LLVM_SYS_201_PREFIX" ;;
         21) env_var="LLVM_SYS_211_PREFIX" ;;
+        22) env_var="LLVM_SYS_221_PREFIX" ;;
         *) return 1 ;;
     esac
 
@@ -124,6 +126,7 @@ get_llvm_prefix() {
         19) env_var="LLVM_SYS_191_PREFIX" ;;
         20) env_var="LLVM_SYS_201_PREFIX" ;;
         21) env_var="LLVM_SYS_211_PREFIX" ;;
+        22) env_var="LLVM_SYS_221_PREFIX" ;;
         *) return 1 ;;
     esac
 
@@ -181,7 +184,7 @@ get_llvm_prefix() {
 
 # Detect available LLVM versions (prefer newer)
 detect_llvm() {
-    for ver in 21 20 19 18; do
+    for ver in 22 21 20 19 18; do
         if check_llvm_version "$ver" >/dev/null 2>&1; then
             echo "$ver"
             return 0
@@ -193,12 +196,12 @@ detect_llvm() {
 # Main logic
 if [ -n "$FORCE_VERSION" ]; then
     case "$FORCE_VERSION" in
-        18|19|20|21)
+        18|19|20|21|22)
             LLVM_VERSION="$FORCE_VERSION"
             ;;
         *)
             echo "Error: Invalid LLVM version '$FORCE_VERSION'"
-            echo "Supported versions: 18, 19, 20, 21"
+            echo "Supported versions: 18, 19, 20, 21, 22"
             exit 1
             ;;
     esac
@@ -208,7 +211,7 @@ else
         echo ""
         echo "Error: No supported LLVM version found."
         echo ""
-        echo "Please install LLVM 18, 19, 20, or 21 and either:"
+        echo "Please install LLVM 18, 19, 20, 21, or 22 and either:"
         echo "  1. Add llvm-config to your PATH"
         echo "  2. Set LLVM_SYS_XXX_PREFIX environment variable"
         echo ""

--- a/openvaf/linker/src/lib.rs
+++ b/openvaf/linker/src/lib.rs
@@ -12,9 +12,10 @@ use cc::windows_registry;
 use target::spec::{LinkerFlavor, Target};
 
 /// Get the LLVM prefix from environment variables.
-/// Checks in order: LLVM 21.1, 20.1, 19.1, 18.1 (newest first).
+/// Checks in order: LLVM 22.1, 21.1, 20.1, 19.1, 18.1 (newest first).
 fn get_llvm_prefix() -> Option<String> {
-    env::var("LLVM_SYS_211_PREFIX")
+    env::var("LLVM_SYS_221_PREFIX")
+        .or_else(|_| env::var("LLVM_SYS_211_PREFIX"))
         .or_else(|_| env::var("LLVM_SYS_201_PREFIX"))
         .or_else(|_| env::var("LLVM_SYS_191_PREFIX"))
         .or_else(|_| env::var("LLVM_SYS_181_PREFIX"))

--- a/openvaf/mir_llvm/Cargo.toml
+++ b/openvaf/mir_llvm/Cargo.toml
@@ -9,17 +9,19 @@ license = "GPL-3.0"
 doctest = false
 
 [features]
-# No default - user must specify --features llvm18/llvm19/llvm20/llvm21
+# No default - user must specify --features llvm18/llvm19/llvm20/llvm21/llvm22
 llvm18 = ["dep:llvm-sys-181"]
 llvm19 = ["dep:llvm-sys-191"]
 llvm20 = ["dep:llvm-sys-201"]
 llvm21 = ["dep:llvm-sys-211"]
+llvm22 = ["dep:llvm-sys-221"]
 
 [dependencies]
 llvm-sys-181 = { package = "llvm-sys", version = "181.2.0", features = ["prefer-dynamic"], optional = true }
 llvm-sys-191 = { package = "llvm-sys", version = "191.0.0", features = ["prefer-dynamic"], optional = true }
 llvm-sys-201 = { package = "llvm-sys", version = "201.0.1", features = ["prefer-dynamic"], optional = true }
 llvm-sys-211 = { package = "llvm-sys", version = "211.0.0", features = ["prefer-dynamic"], optional = true }
+llvm-sys-221 = { package = "llvm-sys", version = "221.0.1", features = ["prefer-dynamic"], optional = true }
 #target-lexicon = "0.12"
 mir = { version = "0.0.0", path = "../mir" }
 target = { version = "0.0.0", path = "../target" }

--- a/openvaf/mir_llvm/src/context.rs
+++ b/openvaf/mir_llvm/src/context.rs
@@ -119,7 +119,7 @@ impl<'a, 'll> CodegenCx<'a, 'll> {
                 0,
             )
         };
-        #[cfg(any(feature = "llvm19", feature = "llvm20", feature = "llvm21"))]
+        #[cfg(any(feature = "llvm19", feature = "llvm20", feature = "llvm21", feature = "llvm22"))]
         let val = unsafe {
             llvm_sys::core::LLVMConstStringInContext2(
                 NonNull::from(self.llcx).as_ptr(),

--- a/openvaf/mir_llvm/src/lib.rs
+++ b/openvaf/mir_llvm/src/lib.rs
@@ -7,6 +7,8 @@ extern crate llvm_sys_191 as llvm_sys;
 extern crate llvm_sys_201 as llvm_sys;
 #[cfg(feature = "llvm21")]
 extern crate llvm_sys_211 as llvm_sys;
+#[cfg(feature = "llvm22")]
+extern crate llvm_sys_221 as llvm_sys;
 
 use std::error::Error;
 use std::ffi::{CStr, CString};

--- a/openvaf/openvaf-driver/Cargo.toml
+++ b/openvaf/openvaf-driver/Cargo.toml
@@ -12,11 +12,12 @@ doctest = false
 test = false
 
 [features]
-# No default - user must specify --features llvm18/llvm19/llvm20/llvm21
+# No default - user must specify --features llvm18/llvm19/llvm20/llvm21/llvm22
 llvm18 = ["openvaf/llvm18"]
 llvm19 = ["openvaf/llvm19"]
 llvm20 = ["openvaf/llvm20"]
 llvm21 = ["openvaf/llvm21"]
+llvm22 = ["openvaf/llvm22"]
 
 [dependencies]
 

--- a/openvaf/openvaf/Cargo.toml
+++ b/openvaf/openvaf/Cargo.toml
@@ -14,6 +14,7 @@ llvm18 = ["dep:llvm-sys-181", "mir_llvm/llvm18", "osdi/llvm18"]
 llvm19 = ["dep:llvm-sys-191", "mir_llvm/llvm19", "osdi/llvm19"]
 llvm20 = ["dep:llvm-sys-201", "mir_llvm/llvm20", "osdi/llvm20"]
 llvm21 = ["dep:llvm-sys-211", "mir_llvm/llvm21", "osdi/llvm21"]
+llvm22 = ["dep:llvm-sys-221", "mir_llvm/llvm22", "osdi/llvm22"]
 
 [dependencies]
 
@@ -27,6 +28,7 @@ llvm-sys-181 = { package = "llvm-sys", version = "181.2.0", optional = true }
 llvm-sys-191 = { package = "llvm-sys", version = "191.0.0", optional = true }
 llvm-sys-201 = { package = "llvm-sys", version = "201.0.1", optional = true }
 llvm-sys-211 = { package = "llvm-sys", version = "211.0.0", optional = true }
+llvm-sys-221 = { package = "llvm-sys", version = "221.0.1", optional = true }
 mir_llvm = { version = "0.0.0", path = "../mir_llvm", default-features = false }
 hir = { version = "0.0.0", path = "../hir" }
 target = { version = "0.0.0", path = "../target" }

--- a/openvaf/openvaf/src/lib.rs
+++ b/openvaf/openvaf/src/lib.rs
@@ -7,6 +7,8 @@ extern crate llvm_sys_191 as llvm_sys;
 extern crate llvm_sys_201 as llvm_sys;
 #[cfg(feature = "llvm21")]
 extern crate llvm_sys_211 as llvm_sys;
+#[cfg(feature = "llvm22")]
+extern crate llvm_sys_221 as llvm_sys;
 
 use std::fs::{create_dir_all, remove_file};
 use std::io::Write;

--- a/openvaf/osdi/Cargo.toml
+++ b/openvaf/osdi/Cargo.toml
@@ -9,11 +9,12 @@ license = "GPL-3.0"
 doctest = false
 
 [features]
-# No default - user must specify --features llvm18/llvm19/llvm20/llvm21
+# No default - user must specify --features llvm18/llvm19/llvm20/llvm21/llvm22
 llvm18 = ["dep:llvm-sys-181", "mir_llvm/llvm18"]
 llvm19 = ["dep:llvm-sys-191", "mir_llvm/llvm19"]
 llvm20 = ["dep:llvm-sys-201", "mir_llvm/llvm20"]
 llvm21 = ["dep:llvm-sys-211", "mir_llvm/llvm21"]
+llvm22 = ["dep:llvm-sys-221", "mir_llvm/llvm22"]
 
 [dependencies]
 
@@ -35,6 +36,7 @@ llvm-sys-181 = { package = "llvm-sys", version = "181.2.0", optional = true }
 llvm-sys-191 = { package = "llvm-sys", version = "191.0.0", optional = true }
 llvm-sys-201 = { package = "llvm-sys", version = "201.0.1", optional = true }
 llvm-sys-211 = { package = "llvm-sys", version = "211.0.0", optional = true }
+llvm-sys-221 = { package = "llvm-sys", version = "221.0.1", optional = true }
 target = { version = "0.0.0", path = "../target"}
 
 typed-index-collections = "3.1"

--- a/openvaf/osdi/build.rs
+++ b/openvaf/osdi/build.rs
@@ -24,7 +24,8 @@ fn main() {
 
     // Use clang from LLVM prefix environment variables (check newest first)
     // Fall back to Homebrew LLVM on macOS, then system clang
-    let clang_path = tracked_env_var_os("LLVM_SYS_211_PREFIX")
+    let clang_path = tracked_env_var_os("LLVM_SYS_221_PREFIX")
+        .or_else(|| tracked_env_var_os("LLVM_SYS_211_PREFIX"))
         .or_else(|| tracked_env_var_os("LLVM_SYS_201_PREFIX"))
         .or_else(|| tracked_env_var_os("LLVM_SYS_191_PREFIX"))
         .or_else(|| tracked_env_var_os("LLVM_SYS_181_PREFIX"))

--- a/openvaf/osdi/src/lib.rs
+++ b/openvaf/osdi/src/lib.rs
@@ -7,6 +7,8 @@ extern crate llvm_sys_191 as llvm_sys;
 extern crate llvm_sys_201 as llvm_sys;
 #[cfg(feature = "llvm21")]
 extern crate llvm_sys_211 as llvm_sys;
+#[cfg(feature = "llvm22")]
+extern crate llvm_sys_221 as llvm_sys;
 
 use std::collections::HashMap;
 use std::ffi::CString;

--- a/verilogae/verilogae/Cargo.toml
+++ b/verilogae/verilogae/Cargo.toml
@@ -16,6 +16,7 @@ llvm18 = ["dep:llvm-sys-181", "mir_llvm/llvm18"]
 llvm19 = ["dep:llvm-sys-191", "mir_llvm/llvm19"]
 llvm20 = ["dep:llvm-sys-201", "mir_llvm/llvm20"]
 llvm21 = ["dep:llvm-sys-211", "mir_llvm/llvm21"]
+llvm22 = ["dep:llvm-sys-221", "mir_llvm/llvm22"]
 
 [dependencies]
 
@@ -34,6 +35,7 @@ llvm-sys-181 = { package = "llvm-sys", version = "181.2.0", optional = true }
 llvm-sys-191 = { package = "llvm-sys", version = "191.0.0", optional = true }
 llvm-sys-201 = { package = "llvm-sys", version = "201.0.1", optional = true }
 llvm-sys-211 = { package = "llvm-sys", version = "211.0.0", optional = true }
+llvm-sys-221 = { package = "llvm-sys", version = "221.0.1", optional = true }
 target = { version = "0.0.0", path = "../../openvaf/target" }
 linker = { version = "0.0.0", path = "../../openvaf/linker" }
 

--- a/verilogae/verilogae/src/lib.rs
+++ b/verilogae/verilogae/src/lib.rs
@@ -7,6 +7,8 @@ extern crate llvm_sys_191 as llvm_sys;
 extern crate llvm_sys_201 as llvm_sys;
 #[cfg(feature = "llvm21")]
 extern crate llvm_sys_211 as llvm_sys;
+#[cfg(feature = "llvm22")]
+extern crate llvm_sys_221 as llvm_sys;
 
 use std::fs;
 use std::io::Write;

--- a/verilogae/verilogae_ffi/Cargo.toml
+++ b/verilogae/verilogae_ffi/Cargo.toml
@@ -17,9 +17,10 @@ verilogae = { version = "1.0.0", path = "../verilogae", optional = true, default
 
 [features]
 default = ["static"]
-# No default LLVM - user must specify --features llvm18/llvm19/llvm20/llvm21
+# No default LLVM - user must specify --features llvm18/llvm19/llvm20/llvm21/llvm22
 static = ["verilogae"]
 llvm18 = ["verilogae?/llvm18"]
 llvm19 = ["verilogae?/llvm19"]
 llvm20 = ["verilogae?/llvm20"]
 llvm21 = ["verilogae?/llvm21"]
+llvm22 = ["verilogae?/llvm22"]

--- a/verilogae/verilogae_py/Cargo.toml
+++ b/verilogae/verilogae_py/Cargo.toml
@@ -26,9 +26,10 @@ pyo3-build-config = { version = "0.19", features = ["resolve-config"] }
 [features]
 
 default = ["static"]
-# No default LLVM - user must specify --features llvm18/llvm19/llvm20/llvm21
+# No default LLVM - user must specify --features llvm18/llvm19/llvm20/llvm21/llvm22
 static = ["verilogae_ffi/static"]
 llvm18 = ["verilogae_ffi/llvm18"]
 llvm19 = ["verilogae_ffi/llvm19"]
 llvm20 = ["verilogae_ffi/llvm20"]
 llvm21 = ["verilogae_ffi/llvm21"]
+llvm22 = ["verilogae_ffi/llvm22"]


### PR DESCRIPTION
This adds support for LLVM 22.1, in the same manner that it was done for LLVM 18+ earlier.

## Tests

Compiled and ran:

```bash
RUN_DEV_TESTS=1 RUN_SLOW_TESTS=1 cargo test --features llvm22
```

Also tested that `configure && build.sh` flow worked as expected for LLVM 22. 

**Setup**

- OS: ArchLinux x86-64
- LLVM: v22.1.3
- Rust/Cargo: v1.95.0

## Notes

- `Cargo.lock`: I only added llvm-sys-221, I didn't run any (other) updates
- `README.md`: A lot of the examples are using LLVM21, I left them as is, and only bumped whatever referenced "latest".