### PR TITLE
Cargo.toml: make salsa a workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ resolver = "2"
 members = ["openvaf/*","melange/*", "verilogae/*", "xtask/", "lib/*", "sourcegen"]
 exclude = ["melange/examples", "verilogae/tests", "openvaf/test_data"]
 
+[workspace.dependencies]
+salsa = "0.17.0-pre.2"
+
 [profile.release]
 lto = "off"
 incremental = true

--- a/openvaf/basedb/Cargo.toml
+++ b/openvaf/basedb/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 
 [dependencies]
 
-salsa = "0.17.0-pre.2"
+salsa = { workspace = true }
 
 stdx = { version = "0.0.0", path = "../../lib/stdx" }
 vfs = { version = "0.0.0", path = "../vfs" }

--- a/openvaf/hir/Cargo.toml
+++ b/openvaf/hir/Cargo.toml
@@ -25,7 +25,7 @@ hir_ty = {version = "0.0.0", path = "../hir_ty" }
 syntax = {version = "0.0.0", path = "../syntax"}
 indexmap = "2.0"
 
-salsa = "0.17.0-pre.2"
+salsa = { workspace = true }
 
 typed-index-collections = "3.1"
 

--- a/openvaf/hir_def/Cargo.toml
+++ b/openvaf/hir_def/Cargo.toml
@@ -21,7 +21,7 @@ syntax = { version = "0.0.0", path = "../syntax" }
 stdx = { version = "0.0.0", path = "../../lib/stdx" }
 arena = { version = "0.0.0", path = "../../lib/arena" }
 
-salsa = "0.17.0-pre.2"
+salsa = { workspace = true }
 once_cell = "1.18"
 
 ordered-float = "4"

--- a/openvaf/hir_lower/Cargo.toml
+++ b/openvaf/hir_lower/Cargo.toml
@@ -28,7 +28,7 @@ indexmap = "2.0"
 lasso = {version = "0.7", features = ["ahash"]}
 
 [dev-dependencies]
-salsa = "0.17.0-pre.2"
+salsa = { workspace = true }
 expect-test = "1.4"
 mini_harness = { version = "0.0.1", path = "../../lib/mini_harness" }
 basedb = { version = "0.0.0", path = "../basedb" }

--- a/openvaf/hir_ty/Cargo.toml
+++ b/openvaf/hir_ty/Cargo.toml
@@ -25,7 +25,7 @@ hir_def = {version = "0.0.0", path = "../hir_def" }
 arena = {version = "0.0.0", path = "../../lib/arena" }
 syntax = {version = "0.0.0", path = "../syntax"}
 
-salsa = "0.17.0-pre.2"
+salsa = { workspace = true }
 
 typed-index-collections = "3.1"
 

--- a/openvaf/osdi/Cargo.toml
+++ b/openvaf/osdi/Cargo.toml
@@ -41,7 +41,7 @@ typed-index-collections = "3.1"
 rustc-hash = "2.0"
 lasso = {version = "0.7", features = ["ahash"]}
 
-salsa = "0.17.0-pre.2"
+salsa = { workspace = true }
 indexmap = "2.0"
 smol_str = {version = "0.2", default-features=false}
 

--- a/verilogae/verilogae/Cargo.toml
+++ b/verilogae/verilogae/Cargo.toml
@@ -58,5 +58,5 @@ ahash = "0.8"
 anyhow = "1"
 termcolor = "1.2"
 
-salsa = "0.17.0-pre.2"
+salsa = { workspace = true }
 camino = "1.1.4"


### PR DESCRIPTION
I was playing with the build, and noticed the dependency on a custom fork of salsa.
I had no luck trying to use upstream instead, as some of the API changed, but in the process, I changed the salsa dependency version tracking to be at the root level rather than duplicated in all of the local crates.
It's not a groundbreaking change, but as it's an improvement still, maybe you will find it of interest.